### PR TITLE
Fixed Read Blocking / Stat Refactor Example

### DIFF
--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -199,7 +199,7 @@ uint16_t HerkulexClass::checkModel(uint8_t servoID)
 
 	uint8_t result[2];
 
-    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 2, result)) return -1;
+    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 6, result)) return -1;
     return (result[1] << 4 | result[0]);
 
 	// packetLength = PACKET_LENGTH_BYTES::HEEPREAD_LENGTH;

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -213,12 +213,9 @@ uint16_t HerkulexClass::checkModel(uint8_t servoID)
 
 	uint8_t result[2];
 
-	// 6 requested bytes: EEPRead always returns an address echo and status bytes. Without 6, we will get
-	// misaligned packets
-
     if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 2, result)) return -1;
 	
-	// model no is 16 bit int, shift over by 8 for correct model
+	// model no is 16 bit int, shift over by 8 for correct model number
     return (result[1] << 8 | result[0]);
 
 	// packetLength = PACKET_LENGTH_BYTES::HEEPREAD_LENGTH;

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -208,15 +208,17 @@ void HerkulexClass::setACKPolicy(int valueACK)
 }
 
 // return full model number as specified in datasheet
-uint16_t HerkulexClass::checkModel(uint8_t servoID)
+bool HerkulexClass::checkModel(uint8_t servoID, uint16_t* model)
 {
-
 	uint8_t result[2];
 
-    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 2, result)) return -1;
+    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 2, result)) {
+		return false;
+	}
 	
 	// model no is 16 bit int, shift over by 8 for correct model number
-    return (result[1] << 8 | result[0]);
+	*model = (result[1] << 8) | result[0];
+    return true;
 
 	// packetLength = PACKET_LENGTH_BYTES::HEEPREAD_LENGTH;
 	// additionalDataLength = PACKET_LENGTH_BYTES::HEEPREAD_DATA_LENGTH;

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -563,8 +563,15 @@ void HerkulexClass::sendPacket(uint8_t servoID, uint8_t* optionalData, uint8_t o
 bool HerkulexClass::readPacketReply(uint8_t servoID, uint8_t* outputBuffer, uint8_t optionalDataLength, COMMAND_RESPONSE cmd_res){
     packetLength = PACKET_LENGTH_BYTES::BASE_LENGTH + optionalDataLength;
 
-    if (!readBlocking(packetLength)) return false;
-    if (!verifyInputPacket(inputBuffer, packetLength)) return false;
+    if (!readBlocking(packetLength)){
+		Serial.println("readBlocking returned nothing."); 
+		return false;
+	}
+	// Something is going wrong in verifyInputPacket
+    if (!verifyInputPacket(inputBuffer, packetLength)){
+		Serial.println("Packet cannot be verified.");
+		return false;
+	}
 
     memcpy(outputBuffer, &inputBuffer[7], optionalDataLength);
     return true;
@@ -646,17 +653,27 @@ void HerkulexClass::updateRead(){
 }
 
 
+
 bool HerkulexClass::readBlocking(uint8_t length){
-	readStartTime = micros();
-	while(_serial->available() < length){
-		delayMicroseconds(50);
-		if (micros() - readStartTime >= SERIAL_READ_TIMEOUT_US){
-			return false;
+    readStartTime = micros();
+	Serial.print("Attempting to read ");
+	Serial.print(packetLength);
+	Serial.println(" bytes");
+    while(_serial->available() < length){
+        delayMicroseconds(50);
+        if (micros() - readStartTime >= SERIAL_READ_TIMEOUT_US){
+            return false;
+        }
+    }
+	if(_serial->available() >= length){
+		_serial->readBytes(inputBuffer, length);
+		for (uint8_t i = 0; i < length; i++) {
+			printHexByte(inputBuffer[i]);
 		}
-		if (_serial->available() >= length){
-			_serial->readBytes(inputBuffer, length);
-			return true;
-		}
+		Serial.println();
+    	return true;
+	} else {
+		return false;
 	}
 }
 

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -127,9 +127,22 @@ void HerkulexClass::initialize(){
 }
 
 // stat
-byte HerkulexClass::stat(int servoID)
+bool HerkulexClass::stat(uint8_t servoID, uint8_t* statError, uint8_t* statDetail)
 {
-	// sendPacket();
+	sendPacket(servoID, nullptr, 0, COMMAND::HSTAT);
+	delayMicroseconds(1000);
+
+	uint8_t buffer[2];
+
+	if(!readPacketReply(servoID, buffer, 2, COMMAND_RESPONSE::HSTAT_RESPONSE)){
+		return false;
+	}
+	*statError = buffer[0];
+	*statDetail = buffer[1];
+	return true;
+
+	//Previous stat code
+	/*
 	packetLength = PACKET_LENGTH_BYTES::HSTAT_LENGTH;
 	additionalDataLength = PACKET_LENGTH_BYTES::HSTAT_DATA_LENGTH;
 
@@ -170,6 +183,7 @@ byte HerkulexClass::stat(int servoID)
 	if (checksumTwo != packet[6]) return -2;
 
 	return packet[7];			// return status
+	*/
 }
 
 // torque on - 
@@ -199,8 +213,13 @@ uint16_t HerkulexClass::checkModel(uint8_t servoID)
 
 	uint8_t result[2];
 
-    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 6, result)) return -1;
-    return (result[1] << 4 | result[0]);
+	// 6 requested bytes: EEPRead always returns an address echo and status bytes. Without 6, we will get
+	// misaligned packets
+
+    if (!readFromEEPRegisterBlocking(servoID, EEP_REGISTER::MOTOR_MODEL, 2, result)) return -1;
+	
+	// model no is 16 bit int, shift over by 8 for correct model
+    return (result[1] << 8 | result[0]);
 
 	// packetLength = PACKET_LENGTH_BYTES::HEEPREAD_LENGTH;
 	// additionalDataLength = PACKET_LENGTH_BYTES::HEEPREAD_DATA_LENGTH;
@@ -523,8 +542,15 @@ void HerkulexClass::requestFromRegister(uint8_t servoID, uint8_t address, uint8_
 bool HerkulexClass::readFromRegisterBlocking(uint8_t servoID, uint8_t address, uint8_t numRequestedBytes, uint8_t* buffer, COMMAND cmd, COMMAND_RESPONSE cmd_res){
 	requestFromRegister(servoID, address, numRequestedBytes, cmd);
 	delayMicroseconds(1000);
-	return readPacketReply(servoID, buffer, numRequestedBytes, cmd_res);
+
+	uint8_t replyOptionalLength = 4 + numRequestedBytes;
+	uint8_t replyBuff[replyOptionalLength];
 	
+	// Since we are taking address and status echo into account, replybuff[2] is where we need to memcpy
+	if (!readPacketReply(servoID, replyBuff, replyOptionalLength, cmd_res)) return false;
+	memcpy(buffer, &replyBuff[2], numRequestedBytes);
+    return true;
+
 }
 
 

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.cpp
@@ -589,12 +589,12 @@ bool HerkulexClass::readPacketReply(uint8_t servoID, uint8_t* outputBuffer, uint
     packetLength = PACKET_LENGTH_BYTES::BASE_LENGTH + optionalDataLength;
 
     if (!readBlocking(packetLength)){
-		Serial.println("readBlocking returned nothing."); 
+		// Serial.println("readBlocking returned nothing."); 
 		return false;
 	}
 	// Something is going wrong in verifyInputPacket
     if (!verifyInputPacket(inputBuffer, packetLength)){
-		Serial.println("Packet cannot be verified.");
+		// Serial.println("Packet cannot be verified.");
 		return false;
 	}
 
@@ -681,9 +681,9 @@ void HerkulexClass::updateRead(){
 
 bool HerkulexClass::readBlocking(uint8_t length){
     readStartTime = micros();
-	Serial.print("Attempting to read ");
-	Serial.print(packetLength);
-	Serial.println(" bytes");
+	// Serial.print("Attempting to read ");
+	// Serial.print(packetLength);
+	// Serial.println(" bytes");
     while(_serial->available() < length){
         delayMicroseconds(50);
         if (micros() - readStartTime >= SERIAL_READ_TIMEOUT_US){
@@ -692,10 +692,10 @@ bool HerkulexClass::readBlocking(uint8_t length){
     }
 	if(_serial->available() >= length){
 		_serial->readBytes(inputBuffer, length);
-		for (uint8_t i = 0; i < length; i++) {
-			printHexByte(inputBuffer[i]);
-		}
-		Serial.println();
+		// for (uint8_t i = 0; i < length; i++) {
+		// 	printHexByte(inputBuffer[i]);
+		// }
+		// Serial.println();
     	return true;
 	} else {
 		return false;

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.h
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.h
@@ -215,7 +215,7 @@ public:
   void endSerialBus();
 
   void  initialize();
-  byte  stat(int servoID);
+  bool  stat(uint8_t servoID, uint8_t* statError, uint8_t* statDetail);
   void  setACKPolicy(int valueACK);
   uint16_t checkModel(uint8_t servoID);
   void  setID(int ID_Old, int ID_New);

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.h
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.h
@@ -217,7 +217,7 @@ public:
   void  initialize();
   bool  stat(uint8_t servoID, uint8_t* statError, uint8_t* statDetail);
   void  setACKPolicy(int valueACK);
-  uint16_t checkModel(uint8_t servoID);
+  bool checkModel(uint8_t servoI,  uint16_t* model);
   void  setID(int ID_Old, int ID_New);
   void  clearError(int servoID);
 

--- a/teensy-motor-drivers/lib/Herkulex/Herkulex.h
+++ b/teensy-motor-drivers/lib/Herkulex/Herkulex.h
@@ -254,6 +254,7 @@ public:
   uint8_t calcChecksumOne();
   uint8_t calcChecksumTwo();
   
+  
   void resetClassVals();
   
   void clearBuffer();

--- a/teensy-motor-drivers/lib/HerkulexMotor/HerkulexMotor.cpp
+++ b/teensy-motor-drivers/lib/HerkulexMotor/HerkulexMotor.cpp
@@ -94,7 +94,11 @@ void HerkulexMotor::setLed(LED_STATE ledColor){
 }
 
 uint16_t HerkulexMotor::getModel(){
-    return SerialBusManager::getBus(_busId).checkModel(_id);
+    uint16_t modelNo;   // hold the model number returned by checkModel here
+    if (SerialBusManager::getBus(_busId).checkModel(_id, &modelNo)) {
+        return modelNo;
+    }
+    return 0xFFFF;
 }
 
 

--- a/teensy-motor-drivers/src/debug.cpp
+++ b/teensy-motor-drivers/src/debug.cpp
@@ -54,7 +54,7 @@ static const char* busName(int b) {
 
 
 //find_all_motors_on_bus
-int find_all_motors_on_bus(HerkulexClass SerialBus){
+int find_all_motors_on_bus(HerkulexClass& SerialBus){
     // loop through all possible pIDs (0-253), every time a motor is found, print and add to motor out
     // packet = data for servos (50) + 8 for move multiple length. See herkulex.h for more details.
     byte status;
@@ -63,33 +63,36 @@ int find_all_motors_on_bus(HerkulexClass SerialBus){
     for (uint8_t pID = 0; pID < 0xFE; pID++){
         // send packet with current pID and wait for ACK packet
         // comments for debugging
+        
+        uint8_t error, detail;
 
-        //status = Herkulex.stat(pID);
-        if(status == 0xFD){
-            // Serial.print("Broadcast on ID ");
-            // Serial.print(pID);
-            // Serial.println(" failed to find motor.");
-            continue;
-        } else if(status == 0xFE){
-            // Serial.print("Broadcast on ID ");
-            // Serial.print(pID);
-            // Serial.println(" failed checksum 2.");
-            continue;
-        } else if(status == 0xFF){
-            // Serial.print("Broadcast on ID ");
-            // Serial.print(pID);
-            // Serial.println(" failed checksum 1.");
-            continue;
-        } else {
+        if (SerialBus.stat(pID, &error, &detail)) {
+            // no errors and there is a motor at that id
             Serial.print("Motor at ID: ");
             Serial.println(pID);
 
-            int modelNo = SerialBus.checkModel(pID);
-            MotorModel model = decodeModel(modelNo);
+            motorCount++;
 
-            Serial.print("Motor model: ");
-            Serial.println(modelName(model));
+            uint16_t modelNo;   // hold the model number returned by checkModel here
+            
+            if (SerialBus.checkModel(pID, &modelNo)) {
+                MotorModel model = decodeModel(modelNo);
+
+                Serial.print("Motor model: ");
+                Serial.println(modelName(model));
+            } else {
+                Serial.println("Motor model: [READ FAILED]");
+            }
+        } else {
+            // Serial.print("Broadcast on ID ");
+            // Serial.print(pID);
+            // Serial.print("   Error: ");
+            // Serial.print(error, HEX);
+            // Serial.print("   Detail: ");
+            // Serial.print(detail, HEX);
+            continue;
         }
+        delayMicroseconds(500);     // Short delay to not overwelm calls on bus
     }
     return motorCount;
 }

--- a/teensy-motor-drivers/src/debug.cpp
+++ b/teensy-motor-drivers/src/debug.cpp
@@ -54,10 +54,9 @@ static const char* busName(int b) {
 
 
 //find_all_motors_on_bus
-int find_all_motors_on_bus(){
+int find_all_motors_on_bus(HerkulexClass SerialBus){
     // loop through all possible pIDs (0-253), every time a motor is found, print and add to motor out
     // packet = data for servos (50) + 8 for move multiple length. See herkulex.h for more details.
-    HerkulexClass Herkulex;
     byte status;
     int motorCount = 0;
 
@@ -85,7 +84,7 @@ int find_all_motors_on_bus(){
             Serial.print("Motor at ID: ");
             Serial.println(pID);
 
-            int modelNo = Herkulex.checkModel(pID);
+            int modelNo = SerialBus.checkModel(pID);
             MotorModel model = decodeModel(modelNo);
 
             Serial.print("Motor model: ");
@@ -94,7 +93,6 @@ int find_all_motors_on_bus(){
     }
     return motorCount;
 }
-
 
 // function that goes through every motor and tests latency for getting and sending position
 void test_motor_latency(HerkulexMotor* motors, int motors_size){

--- a/teensy-motor-drivers/src/debug.cpp
+++ b/teensy-motor-drivers/src/debug.cpp
@@ -83,6 +83,7 @@ int find_all_motors_on_bus(HerkulexClass& SerialBus){
             } else {
                 Serial.println("Motor model: [READ FAILED]");
             }
+            Serial.println();
         } else {
             // Serial.print("Broadcast on ID ");
             // Serial.print(pID);

--- a/teensy-motor-drivers/src/debug.cpp
+++ b/teensy-motor-drivers/src/debug.cpp
@@ -65,7 +65,7 @@ int find_all_motors_on_bus(){
         // send packet with current pID and wait for ACK packet
         // comments for debugging
 
-        status = Herkulex.stat(pID);
+        //status = Herkulex.stat(pID);
         if(status == 0xFD){
             // Serial.print("Broadcast on ID ");
             // Serial.print(pID);

--- a/teensy-motor-drivers/src/debug.cpp
+++ b/teensy-motor-drivers/src/debug.cpp
@@ -22,9 +22,9 @@
 MotorModel decodeModel(int rawModel)
 {
     switch (rawModel) {
-        case 0x0201: return DRS_0201;
-        case 0x0601: return DRS_0601;
-        case 0x0602: return DRS_0602;
+        case 0x0102: return DRS_0201;
+        case 0x0106: return DRS_0601;
+        case 0x0206: return DRS_0602;
         default:     return UNKNOWN_MODEL;
     }
 }

--- a/teensy-motor-drivers/src/debug.h
+++ b/teensy-motor-drivers/src/debug.h
@@ -3,5 +3,7 @@
 #include <HerkulexMotor.h>
 
 void debug_motors(HerkulexMotor *motors, int motors_size);
+int find_all_motors_on_bus(HerkulexClass& SerialBus);
+void test_motor_latency(HerkulexMotor* motors, int motors_size);
 
 #endif

--- a/teensy-motor-drivers/src/main.cpp
+++ b/teensy-motor-drivers/src/main.cpp
@@ -89,6 +89,9 @@ void setup(){
     Serial.println(motors[i].getModel());
   }
 
+  // Futur print for testing
+  //Serial.println(SerialBusManager::getBus(BUS_R_LEG).stat())
+
 
 
 }

--- a/teensy-motor-drivers/src/main.cpp
+++ b/teensy-motor-drivers/src/main.cpp
@@ -71,10 +71,12 @@ void setup(){
   delay(2000);
 
   //scan the serial buses for unknown motor ids
+  Serial.println();
   Serial.println("Scanning BUS_R_LEG...");
   int countR = find_all_motors_on_bus(SerialBusManager::getBus(BUS_R_LEG));
   Serial.print("Found motors on R_LEG: ");
   Serial.println(countR);
+  Serial.println();
 
   for (int i = 0; i < MOTOR_COUNT; i++){
     motors[i].setLed(LED_STATE::LED_BLUE);

--- a/teensy-motor-drivers/src/main.cpp
+++ b/teensy-motor-drivers/src/main.cpp
@@ -58,18 +58,23 @@ void setup(){
   Serial8.begin(9600); //begin serial communication with the raspberry pi, this has been changed to Serial 8 instead of 1
   delay(2000);
 
-  // if (!imu1.begin()) {
-  //     Serial.println("ERROR: IMU not detected. Check wiring!");
-  //     while (1);
-  // }
+  if (!imu1.begin()) {
+      Serial.println("ERROR: IMU not detected. Check wiring!");
+      while (1);
+  }
 
   // initialize all serial buses
   SerialBusManager::createBus(SERIAL_BUS::BUS_L_LEG); // begin serial communications with motor, these are on Serial 2
   SerialBusManager::createBus(SERIAL_BUS::BUS_R_LEG);
   SerialBusManager::startAllBuses(115200);
-  SerialBusManager::initAllMotors();
-
+  // SerialBusManager::initAllMotors();
   delay(2000);
+
+  //scan the serial buses for unknown motor ids
+  Serial.println("Scanning BUS_R_LEG...");
+  int countR = find_all_motors_on_bus(SerialBusManager::getBus(BUS_R_LEG));
+  Serial.print("Found motors on R_LEG: ");
+  Serial.println(countR);
 
   for (int i = 0; i < MOTOR_COUNT; i++){
     motors[i].setLed(LED_STATE::LED_BLUE);
@@ -86,7 +91,12 @@ void setup(){
 
 
   for (int i = 0; i < MOTOR_COUNT; i++){
-    Serial.println(motors[i].getModel());
+    uint16_t model = motors[i].getModel();
+    if (model == 0xFFFF) {
+      Serial.println("Read failed");
+    } else {
+      Serial.println(model);
+    }
   }
 
   // Futur print for testing


### PR DESCRIPTION
Changes for Pull Request:

- Updated read blocking to handle correct packet size. We were not getting the correct amount of bites from the RAM read in readRegisterBlocking because RAM Reads seem to always be returning an address and stat echo in the packet. Thus, we have to account for 4 extra bytes on top of whatever optional data we request. This is why we now have 

           uint8_t replyOptionalLength = 4 + numRequestedBytes; 

at line 543 in Herkulex.cpp.

- Refactored stat command to use sendPacket and receivePacketReply functions. Essentially sends a packet with 0 optional data and the stat command header, and then recieves that stat command packet back. The stat command function now returns a bool (true or false for successful stat read or not), and sends statError and statDetail replies to pointer values that you input in the function. (example: Herkulex.stat( 42,  *statErrorBuff, *statDetaiBuffl) will send the stat error code and detail to statErrorBuff and statDetailBuff) of motor 42). The previous code for stat is commented out in the function, so it can serve as a refactoring example.


There should be print statements that highlight everything thats going on with the packets in read blocking to verify the output. Example of desired output would be:

0xFF 0xFF 0x0D 0x0C 0x42 0x04 0xFA 0x00 0x02 0x06 0x01 0x00 0x42 
262
Attempting to read 13 bytes
0xFF 0xFF 0x0D 0x05 0x42 0x0C 0xF2 0x00 0x02 0x06 0x01 0x00 0x42 
262
Attempting to read 13 bytes
0xFF 0xFF 0x0D 0x01 0x42 0x08 0xF6 0x00 0x02 0x06 0x01 0x00 0x42
262

262 is the decimal form of 0x0106, which is the little-endian form of reading 0601 (the correct model number). All we have to do is add in enum handling for these little-endian numbers to get the actual model type printed to the screen.


_the first three bytes should always be the same (header)
The 10th and 11th positions. (0x06 0x01) denotes the motor model_